### PR TITLE
Fix: correct parsing of transaction status to handle unknown statuses

### DIFF
--- a/src/pyconiq/integrations/base.py
+++ b/src/pyconiq/integrations/base.py
@@ -168,25 +168,21 @@ class TransactionStatus(StrEnum):
             TransactionStatus.FAILED,
             TransactionStatus.SUCCEEDED,
         }
-
     @staticmethod
     def parse(state: dict[str, Any]) -> TransactionStatus:
         r"""
         Returns a TransactionStatus instance based on the raw state of a Transaction.
         """
         status = state.get("status", None)
-
         assert status is not None
-
         status = status.upper()
-
-        if status not in TransactionStatus:
+    
+        if status not in TransactionStatus._value2member_map_:
             raise UnknownTransactionStatusError(
                 f"{status} is not a valid transaction status."
             )
-
-        return TransactionStatus[status]
-
+    
+        return TransactionStatus(status)
 
 @dataclass
 class TransactionLinks:


### PR DESCRIPTION
1.
if status not in TransactionStatus._value2member_map_:
    raise UnknownTransactionStatusError(...)
is correcter dan:
if status not in TransactionStatus:

TransactionStatus is meestal een Enum klasse.
Je kunt controleren of een value bestaat in een enum op twee manieren:
Checken of de waarde voorkomt in de waarden van de enum (dus niet de keys/namen).
Checken of de waarde voorkomt in de keys of een interne mapping.

TransactionStatus._value2member_map_ is een interne dict van Python Enum die waarden (values) koppelt aan de enumleden. Dit is de correcte manier om te checken of een value (zoals een string 'PENDING') geldig is.

Als je if status not in TransactionStatus: gebruikt, check je of status een enum-lid is (de naam), wat meestal niet werkt voor waarden.


2.
    TransactionStatus[status] zoekt een enum-lid op via de naam (key) van het enum-lid.
    TransactionStatus(status) maakt een enum-lid aan via de waarde.
Bijvoorbeeld:
class TransactionStatus(Enum):
    PENDING = "PENDING"
    CANCELLED = "CANCELLED"
TransactionStatus['PENDING']    # zoekt lid met naam 'PENDING'
TransactionStatus('PENDING')    # zoekt lid met waarde 'PENDING'

Als je status de string 'PENDING' is en de enum definieert waarden als 'PENDING', dan doen beide vaak hetzelfde.
Maar:
    TransactionStatus(status) is de juiste manier als status een value is.
    TransactionStatus[status] werkt alleen als status exact de naam van het enum-lid is.